### PR TITLE
Improve console output

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-aws-lambda-swift",
-  "version": "1.0.4",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-aws-lambda-swift",
-      "version": "1.0.4",
+      "version": "1.1.8",
       "workspaces": [
         "packages/*"
       ],

--- a/vscode-extension/webview-ui/src/components/console/Console.css
+++ b/vscode-extension/webview-ui/src/components/console/Console.css
@@ -28,7 +28,7 @@
     white-space: nowrap;
     overflow-x: auto;
 }
-
-.console-output p {
+.console-output pre {
+    line-height: 1em;
     margin: 0;
 }

--- a/vscode-extension/webview-ui/src/components/console/Console.tsx
+++ b/vscode-extension/webview-ui/src/components/console/Console.tsx
@@ -62,7 +62,7 @@ const Console = () => {
       {/* Console output */}
       <div className="console-output" ref={consoleRef}>
         {consoleMessages.map((message, index) => (
-          <p key={index}>{message}</p>
+          <pre key={index}>{message}</pre>
         ))}
       </div>
     </div>


### PR DESCRIPTION
Fix #1 
The issue was that `\n` chars present in `stdErr` or `stdOut` are being replaced by spaces (` `) by the `<p>` tag.
I switched to `<pre>` to preserve text formatting.
I reduce line height to `1em` to avoid vertical spaces between the lines.

From [W3 School](https://www.w3schools.com/tags/tag_pre.asp)

> Text in a `<pre>` element is displayed in a fixed-width font, and the text preserves both spaces and line breaks. The text will be displayed exactly as written in the HTML source code.
